### PR TITLE
[Feat] 히스토리 수정 시 기존 사진 유지 및 수정 폼에 미리보기 추가

### DIFF
--- a/src/main/java/com/fairplay/controller/HistoryController.java
+++ b/src/main/java/com/fairplay/controller/HistoryController.java
@@ -349,15 +349,15 @@ public class HistoryController {
 	    if (!groupMemberService.isGroupMember(groupId, loginUserId)) {
 	        return "redirect:/";
 	    }
+	    
+	    // 기존 히스토리 불러오기
+	    History oldHistory = historyService.getHistoryByIdWithDetails(id);
 
 	    History history = new History();
 	    history.setId(id);
 	    history.setTodo_id(todoId);
 	    history.setMember_id(memberId);
-
-	    // 사용자가 선택한 날짜 그대로 저장
-	    history.setCompleted_at(completedAt);
-
+	    history.setCompleted_at(completedAt);	// 사용자가 선택한 날짜 그대로 저장
 	    history.setScore(score);
 	    history.setMemo(memo);
 
@@ -371,6 +371,9 @@ public class HistoryController {
 	        } catch (Exception e) {
 	            e.printStackTrace();
 	        }
+	    } else {
+        // 새 파일 없으면 기존 사진 유지
+        history.setPhoto(oldHistory.getPhoto());
 	    }
 
 	    historyService.updateHistory(history);

--- a/src/main/webapp/WEB-INF/views/historyUpdateForm.jsp
+++ b/src/main/webapp/WEB-INF/views/historyUpdateForm.jsp
@@ -60,6 +60,10 @@
 
       <div class="form-group">
         <label>인증샷 업로드</label>
+        <c:if test="${not empty history.photo}">
+        	<img src="${pageContext.request.contextPath}/upload/${history.photo}" 
+             alt="기존 인증샷" style="max-width:100px; display:block; margin-bottom:10px;">
+    		</c:if>
         <input type="file" name="photo" accept="image/*" />
       </div>
 


### PR DESCRIPTION
## 작업내용
- 기존에는 수정 시 파일을 선택하지 않으면 photo 필드가 null로 덮여 기존 사진이 사라지는 문제가 있었음
- 사용자 경험 개선을 위해 수정 화면에서 기존 사진을 확인할 수 있도록 미리보기 기능을 추가함

- 히스토리 수정 시 새 파일을 업로드하지 않아도 기존 사진이 유지되도록 로직 수정
- updateForm에 기존 사진을 미리 보여주는 UI 추가
