### PR TITLE
배포 환경 분리를 위한 프로퍼티 동적 로드 구조 구현

### DIFF
--- a/.settings/org.eclipse.m2e.core.prefs
+++ b/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,5 @@
-activeProfiles=
+activeProfiles=local
+eclipse.m2.autoUpdateProjects=true
 eclipse.preferences.version=1
 resolveWorkspaceProjects=true
 version=1

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.fairplay</groupId>
   <artifactId>fairplay</artifactId>
@@ -7,6 +9,7 @@
   <version>0.0.1-SNAPSHOT</version>
   <name>fairplay Maven Webapp</name>
   <url>http://maven.apache.org</url>
+
   <properties>
 	 <!--자바의 버전을 정의-->
 	 <java-version>17</java-version>
@@ -23,12 +26,8 @@
 	 <security-version>5.6.3</security-version>
   </properties>
   
-  
-  
-  
   <dependencies>
-  
-  	
+
   	<!-- Tiles -->
   	<dependency>
   		<groupId>org.apache.tiles</groupId>
@@ -49,7 +48,6 @@
   	</dependency>
   	
   	<!-- MY SQL -->
-  	
   	<dependency>
   		<groupId>org.springframework</groupId>
   		<artifactId>spring-jdbc</artifactId>
@@ -68,7 +66,6 @@
 	    <version>8.0.24</version>
 	</dependency>
 
-  	
   	<!-- Validation -->
   	<dependency>
   		<groupId>javax.validation</groupId>
@@ -81,56 +78,49 @@
   		<artifactId>hibernate-validator</artifactId>
   		<version>5.4.2.Final</version>
   	</dependency>
-  	
-  	<!-- Web Flow -->
-<!--  	<dependency> 기존에 작성된 Web Flow-->
-<!--  		<groupId>org.springframework.webflow</groupId>-->
-<!--  		<artifactId>spring-webflow</artifactId>-->
-<!--  		<version>2.5.1.RELEASE</version>-->
-<!--  	</dependency>-->
 
-      <!--새로 작성된 Web Flow -->
-      <dependency>
-          <groupId>org.springframework.webflow</groupId>
-          <artifactId>spring-webflow</artifactId>
-          <version>2.5.1.RELEASE</version>
-          <exclusions><!--spring-webflow의 하위 스프링 의존성 제외-->
-              <exclusion>
-                  <groupId>org.springframework</groupId>
-                  <artifactId>spring-beans</artifactId>
-              </exclusion>
-              <exclusion>
-                  <groupId>org.springframework</groupId>
-                  <artifactId>spring-expression</artifactId>
-              </exclusion>
-              <exclusion>
-                  <groupId>org.springframework</groupId>
-                  <artifactId>spring-web</artifactId>
-              </exclusion>
-          </exclusions>
-      </dependency>
-      <!--새로 작성된 Web Flow -->
+    <!-- Web Flow -->
+    <dependency>
+        <groupId>org.springframework.webflow</groupId>
+        <artifactId>spring-webflow</artifactId>
+        <version>2.5.1.RELEASE</version>
+        <!-- webflow가 내부적으로 가져오는 구버전 spring과 충돌 방지 -->
+        <exclusions>
+            <exclusion>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-beans</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-expression</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+    <!-- Web Flow -->
 
-      <!-- 스프링 최신버전(5.3.19)으로 명시 고정 -->
-      <dependency>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-beans</artifactId>
-          <version>${org.springframework-version}</version>
-      </dependency>
+    <!-- 제외한 spring 라이브러리를 현재 프로젝트 버전으로 직접 맞춰줌 -->
+    <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-beans</artifactId>
+        <version>${org.springframework-version}</version>
+    </dependency>
 
-      <dependency>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-expression</artifactId>
-          <version>${org.springframework-version}</version>
-      </dependency>
+    <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-expression</artifactId>
+        <version>${org.springframework-version}</version>
+    </dependency>
 
-      <dependency>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-web</artifactId>
-          <version>${org.springframework-version}</version>
-      </dependency>
-      <!-- 스프링 최신버전(5.3.19)으로 명시 고정 -->
-  	
+    <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-web</artifactId>
+        <version>${org.springframework-version}</version>
+    </dependency>
+
  	<dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-context</artifactId>
@@ -150,15 +140,12 @@
     	<version>${org.springframework-version}</version>
 	</dependency>
 
-
-    <!--스프링 프레임워크에서 spring-webmvc 객체들을 주십시요-->
     <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-webmvc</artifactId>
         <version>${org.springframework-version}</version>
     </dependency>   
-    
- 
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -169,23 +156,24 @@
     <dependency>
 	    <groupId>javax.servlet</groupId>
 	    <artifactId>jstl</artifactId>
-	    <version>1.2</version> <!-- 또는 최신 버전 -->
+	    <version>1.2</version>
 	</dependency>
 
-      <!--저의 환경에서 톰캣을 구동하기 위해서 넣은겁니다. 문제시 제거하세요.-->
-      <dependency>
-          <groupId>javax.servlet</groupId>
-          <artifactId>javax.servlet-api</artifactId>
-          <version>4.0.1</version>
-          <scope>provided</scope>
-      </dependency>
-      
-      <!--저의 환경에서 톰캣을 구동하기 위해서 넣은겁니다. 문제시 제거하세요.-->
+    <!--저의 환경에서 톰캣을 구동하기 위해서 넣은겁니다. 문제시 제거하세요.-->
+    <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>javax.servlet-api</artifactId>
+        <version>4.0.1</version>
+        <scope>provided</scope>
+    </dependency>
+    
+    <!--저의 환경에서 톰캣을 구동하기 위해서 넣은겁니다. 문제시 제거하세요.-->
 	<dependency>
 	    <groupId>org.springframework.security</groupId>
 	    <artifactId>spring-security-web</artifactId>
 	    <version>${security-version}</version>
     </dependency>
+
     <dependency>
 	    <groupId>org.springframework.security</groupId>
 	    <artifactId>spring-security-config</artifactId>
@@ -197,145 +185,179 @@
 	    <artifactId>spring-security-taglibs</artifactId>
 	    <version>${security-version}</version>
     </dependency>
-    
-    
+
     <dependency>
     	<groupId>commons-fileupload</groupId>
     	<artifactId>commons-fileupload</artifactId>
     	<version>${commons-fileupload-version}</version>
     </dependency>
-    
+
     <dependency>
     	<groupId>commons-io</groupId>
     	<artifactId>commons-io</artifactId>
     	<version>${commons-io-version}</version>
     </dependency>
-    
-    <!-- Logging -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${org.slf4j-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <version>${org.slf4j-version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${org.slf4j-version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.15</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.mail</groupId>
-                    <artifactId>mail</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.jms</groupId>
-                    <artifactId>jms</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jdmk</groupId>
-                    <artifactId>jmxtools</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jmx</groupId>
-                    <artifactId>jmxri</artifactId>
-                </exclusion>
-            </exclusions>
-            <scope>runtime</scope>
-        </dependency>
 
-		<!-- JSON 변환기: jackson-databind -->
-		<dependency>
-		    <groupId>com.fasterxml.jackson.core</groupId>
-		    <artifactId>jackson-databind</artifactId>
-		    <version>2.13.5</version>
-		</dependency>
-        
-		<dependency>
-		  <groupId>com.fasterxml.jackson.datatype</groupId>
-		  <artifactId>jackson-datatype-jsr310</artifactId>
-		  <version>2.13.5</version> <!-- 내가 쓰는 버전에 맞게 조정 -->
-		</dependency>
-		
+    <!-- Logging -->
+    <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${org.slf4j-version}</version>
+    </dependency>
+
+    <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <version>${org.slf4j-version}</version>
+        <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-log4j12</artifactId>
+        <version>${org.slf4j-version}</version>
+        <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+        <groupId>log4j</groupId>
+        <artifactId>log4j</artifactId>
+        <version>1.2.15</version>
+        <exclusions>
+            <exclusion>
+                <groupId>javax.mail</groupId>
+                <artifactId>mail</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>javax.jms</groupId>
+                <artifactId>jms</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>com.sun.jdmk</groupId>
+                <artifactId>jmxtools</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>com.sun.jmx</groupId>
+                <artifactId>jmxri</artifactId>
+            </exclusion>
+        </exclusions>
+        <scope>runtime</scope>
+    </dependency>
+
+	<!-- JSON 변환기 -->
+	<dependency>
+	    <groupId>com.fasterxml.jackson.core</groupId>
+	    <artifactId>jackson-databind</artifactId>
+	    <version>2.13.5</version>
+	</dependency>
+
+	<dependency>
+	  <groupId>com.fasterxml.jackson.datatype</groupId>
+	  <artifactId>jackson-datatype-jsr310</artifactId>
+	  <version>2.13.5</version>
+	</dependency>
+
     <dependency>
 	    <groupId>org.springframework</groupId>
 	    <artifactId>spring-context-support</artifactId>
 	    <version>${org.springframework-version}</version> 
 	</dependency>
-    
-    <!-- JavaMail API (Jakarta Mail 또는 javax.mail) -->
-	<dependency>
+
+    <dependency>
 	    <groupId>com.sun.mail</groupId>
 	    <artifactId>jakarta.mail</artifactId>
 	    <version>1.6.7</version>
-	</dependency>  
-	
+	</dependency>
+
 	<dependency>
 	    <groupId>org.springframework.security</groupId>
 	    <artifactId>spring-security-crypto</artifactId>
 	    <version>${security-version}</version>
-	</dependency>  
-    
+	</dependency>
+
   </dependencies>
-  
-	<build>
-		<finalName>fairplay</finalName>
-        <!--빌드시 필요한 확장 기능을 추가-->
-        <plugins>
-            <!--저의 환경에서 dependency:tree기능을 사용하기 위해 임의로 추가한 플러그인입니다. 문제 발생시 제거 하세요. -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.0</version> <!-- 안정적인 버전 -->
-            </plugin>
-            <!--저의 환경에서 dependency:tree기능을 사용하기 위해 임의로 추가한 플러그인입니다. 문제 발생시 제거 하세요. -->
-            <!--스프링 배포를 위한 이클립스 플러긴을 도입 -->
-            <plugin>
-                <artifactId>maven-eclipse-plugin</artifactId>
-                <version>2.9</version>
-                <configuration>
-                    <additionalProjectnatures>
-                        <projectnature>org.springframework.ide.eclipse.core.springnature</projectnature>
-                    </additionalProjectnatures>
-                    <additionalBuildcommands>
-                        <buildcommand>org.springframework.ide.eclipse.core.springbuilder</buildcommand>
-                    </additionalBuildcommands>
-                    <downloadSources>true</downloadSources>
-                    <downloadJavadocs>true</downloadJavadocs>
-                </configuration>
-            </plugin>
-            <!-- 배포시 메이븐컴파일러(자바컴파일러포함)를 해당버전으로 교체-->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
-                <configuration>
-                    <source>17</source>
-                    <target>17</target>
-                    <compilerArgument>-Xlint:all</compilerArgument>
-                    <showWarnings>true</showWarnings>
-                    <showDeprecation>true</showDeprecation>
-                </configuration>
-            </plugin>
-        
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.2.1</version>
-                <configuration>
-                    <mainClass>org.test.int1.Main</mainClass>
-                </configuration>
-            </plugin>
-        </plugins>
+
+  <!-- 실행 환경(local / prod)을 나누기 위한 설정 -->
+  <profiles>
+      <profile>
+          <id>local</id>
+          <activation>
+              <!-- 별도 지정 없으면 local 환경 -->
+              <activeByDefault>true</activeByDefault>
+          </activation>
+          <properties>
+              <environment>local</environment>
+          </properties>
+      </profile>
+
+      <profile>
+          <id>prod</id>
+          <properties>
+              <!-- 배포 환경 -->
+              <environment>prod</environment>
+          </properties>
+      </profile>
+  </profiles>
+
+  <build>
+	<finalName>fairplay</finalName>
+
+    <!-- 환경에 따라 다른 properties 파일을 읽도록 처리 -->
+    <resources>
+	    <resource>
+	        <directory>src/main/resources</directory>
+	        <filtering>true</filtering> <includes>
+	            <include>**/*.xml</include>
+	            <include>**/*.properties</include>
+	        </includes>
+	        <excludes>
+	            <exclude>config-local.properties</exclude>
+	            <exclude>config-prod.properties</exclude>
+	        </excludes>
+	    </resource>
+	    
+	    <resource>
+	        <directory>src/main/resources</directory>
+	        <filtering>true</filtering>
+	        <includes>
+	            <include>config-${environment}.properties</include>
+	        </includes>
+	    </resource>
+	</resources>
+
+    <plugins>
+
+        <!--저의 환경에서 dependency:tree기능을 사용하기 위해 임의로 추가한 플러그인입니다. 문제 발생시 제거 하세요. -->
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>3.6.0</version>
+        </plugin>
+
+        <!--스프링 배포를 위한 이클립스 플러긴을 도입 -->
+        <plugin>
+            <artifactId>maven-eclipse-plugin</artifactId>
+            <version>2.9</version>
+        </plugin>
+
+        <!-- 배포시 메이븐컴파일러 -->
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>2.5.1</version>
+            <configuration>
+                <source>17</source>
+                <target>17</target>
+            </configuration>
+        </plugin>
+
+        <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.2.1</version>
+        </plugin>
+
+    </plugins>
   </build>
+
 </project>

--- a/src/main/java/com/fairplay/config/WebConfig.java
+++ b/src/main/java/com/fairplay/config/WebConfig.java
@@ -17,7 +17,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         
-        // [수정내용] OS 환경에 따른 업로드 경로 동적 설정 (AWS 배포 대비)
+        // OS 환경에 따른 업로드 경로 동적 설정 (AWS 배포 대비)
         String os = System.getProperty("os.name").toLowerCase();
         String uploadPath;
         String profilePath;
@@ -27,13 +27,13 @@ public class WebConfig implements WebMvcConfigurer {
             uploadPath = "file:///C:/upload/";
             profilePath = "file:///C:/upload/profile/";
         } else {
-            // AWS 리눅스 환경 (EC2 등) - 보통 /home/ubuntu/upload 등을 사용합니다.
-            // 관리자 권한 문제가 없는 사용자 홈 디렉토리 하위를 권장합니다.
+            // AWS 리눅스 환경 (EC2 등) - /home/ubuntu/upload 등
+            // 관리자 권한 문제가 없는 사용자 홈 디렉토리 하위를 권장
             uploadPath = "file:/home/ubuntu/upload/";
             profilePath = "file:/home/ubuntu/upload/profile/";
         }
 
-        // 최종 경로는 /upload/ → 설정된 경로에서 파일 찾음
+        // 최종 경로는 /upload/ -> 설정된 경로에서 파일 찾음
         // /** 와일드카드를 추가하여 하위 파일 접근 허용
         registry.addResourceHandler("/upload/**")
                 .addResourceLocations(uploadPath);

--- a/src/main/java/com/fairplay/util/FileUploadUtil.java
+++ b/src/main/java/com/fairplay/util/FileUploadUtil.java
@@ -11,22 +11,21 @@ import org.springframework.web.multipart.MultipartFile;
 @Component
 public class FileUploadUtil {
 
-    // 프로필 이미지 저장 경로 (C:/upload/)
+    // 프로필 이미지 저장 경로 (config-local.properties의 값을 읽어옴)
     @Value("${upload.path}")
     private String uploadPath;
 
-    // 하위 폴더(subDir)를 파라미터로 받아 유연하게 저장하는 메서드 추가
+    // 하위 폴더(subDir)를 파라미터로 받아 유연하게 저장하는 메서드
     public String saveFile(MultipartFile file, String subDir) {
         if (file == null || file.isEmpty()) {
             return null;
         }
 
         try {
-            // 루트 경로와 하위 폴더(profile/)를 합침
-            String finalPath = uploadPath + subDir;
+            // 경로 사이에 슬래시(/)가 누락되지 않도록 File 객체를 활용해 경로 병합
+            File uploadDir = new File(uploadPath, subDir);
             
-            // 저장 경로 폴더가 없으면 생성하는 로직 추가 (안정성 강화)
-            File uploadDir = new File(finalPath);
+            // 저장 경로 폴더가 없으면 생성 (C:/upload/profile/ 형태)
             if (!uploadDir.exists()) {
                 uploadDir.mkdirs();
             }
@@ -38,13 +37,13 @@ public class FileUploadUtil {
             String uuid = UUID.randomUUID().toString();
             String newFileName = uuid + "_" + safeFileName;
 
-            // 최종 경로(finalPath)를 사용하여 파일 객체 생성
-            File destination = new File(finalPath, newFileName);
+            // 최종 파일 객체 생성 및 저장
+            File destination = new File(uploadDir, newFileName);
             file.transferTo(destination);
 
-            return newFileName;
+            // DB에는 파일명만 저장하지만, 나중에 불러올 때 'profile/파일명' 구조가 되어야 함
+            return newFileName; 
         } catch (IOException e) {
-            // 디버깅을 위해 에러 로그 출력
             e.printStackTrace();
             return null;
         }
@@ -55,11 +54,10 @@ public class FileUploadUtil {
         return saveFile(file, "");
     }
 
-    // 기존 파일 삭제 시에도 하위 폴더를 고려하도록 수정 가능
+    // 기존 파일 삭제
     public void deleteFile(String fileName) {
         if (fileName == null) return;
-
-        File file = new File(uploadPath + fileName);
+        File file = new File(uploadPath, fileName);
         if (file.exists()) {
             file.delete();
         }
@@ -68,8 +66,10 @@ public class FileUploadUtil {
     // 하위 폴더 경로를 포함한 삭제 메서드
     public void deleteFile(String fileName, String subDir) {
         if (fileName == null) return;
-
-        File file = new File(uploadPath + subDir + fileName);
+        // 삭제 시에도 경로 병합을 안전하게 처리
+        File dir = new File(uploadPath, subDir);
+        File file = new File(dir, fileName);
+        
         if (file.exists()) {
             file.delete();
         }

--- a/src/main/resources/config-local.properties
+++ b/src/main/resources/config-local.properties
@@ -3,6 +3,5 @@ db.url=jdbc:mysql://localhost:3306/fairplay_db?serverTimezone=Asia/Seoul
 db.username=root
 db.password=1234
 
-upload.path=C:/upload/
-
-# upload.path=/home/ubuntu/upload/
+# 이미지 업로드 경로 추가 (본인의 실제 경로로 수정하세요)
+upload.path=C:/upload

--- a/src/main/resources/config-prod.properties
+++ b/src/main/resources/config-prod.properties
@@ -1,0 +1,6 @@
+# 운영 환경(AWS/Docker) DB 설정
+# 나중에 배포 서버 엔드포인트 확인 후 아래 URL을 수정하세요.
+db.driver=com.mysql.cj.jdbc.Driver
+db.url=jdbc:mysql://[배포-서버-주소]:3306/fairplay?serverTimezone=Asia/Seoul
+db.username=admin
+db.password=1234

--- a/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
+++ b/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
@@ -3,47 +3,40 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xsi:schemaLocation="http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd
 		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
-	<!-- mvc 네임스페이스 접두어를 추가하여 선언 오류 해결 -->
-	<mvc:annotation-driven enable-matrix-variables="true" validator="validator"/>
+	<annotation-driven enable-matrix-variables="true" validator="validator"/>
 
-	<!-- root-context에서 로드한 db.properties의 ${upload.path}를 이 파일에서도 사용하기 위해 추가 -->
-	<!-- 만약 여기서 ${upload.path}를 인식하지 못해 404가 발생한다면 아래 한 줄이 필요합니다. -->
-	<context:property-placeholder location="classpath:db.properties" />
-
-	<!-- 정적 자원 매핑에도 mvc 접두어 사용 -->
-	<mvc:resources mapping="/resources/**" location="/resources/" />
+	<resources mapping="/resources/**" location="/resources/" />
 	
-	<!-- upload.path 관련 설정 (db.properties에 정의되어 있어야 함) -->
-	<!-- 수정 포인트: 'file:' 뒤에 프로퍼티 값을 연결. 경로 끝에 / 처리는 db.properties 설정에 맞게 조절 -->
-	<mvc:resources mapping="/upload/**" location="file:${upload.path}/" />
+	<resources mapping="/upload/**" location="file:${upload.path}/" />
 	
-	<!-- 뷰 리졸버 설정 -->
 	<beans:bean class="org.springframework.web.servlet.view.InternalResourceViewResolver">
 		<beans:property name="prefix" value="/WEB-INF/views/" />
 		<beans:property name="suffix" value=".jsp" />
 	</beans:bean>
 	
-	<!-- 컴포넌트 스캔 (Controller 등) -->
+	<beans:bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer">
+	    <beans:property name="locations">
+	        <beans:list>
+	            <beans:value>classpath:config-${environment}.properties</beans:value>
+	        </beans:list>
+	    </beans:property>
+	</beans:bean>
+	
 	<context:component-scan base-package="com.fairplay" />
 
-	<!-- 파일 업로드 설정 -->
 	<beans:bean id="multipartResolver" class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
 		 <beans:property name="maxUploadSize" value="10240000"/>
-		 <!-- 한글 파일명 깨짐 방지를 위해 defaultEncoding 설정을 추가했습니다. -->
 		 <beans:property name="defaultEncoding" value="UTF-8" />
 	</beans:bean>
 
-	<!-- 유효성 검사 설정 -->
 	<beans:bean id="validator" class="org.springframework.validation.beanvalidation.LocalValidatorFactoryBean">
 		<beans:property name="validationMessageSource" ref="messageSource" />
 	</beans:bean>
 	
-	<!-- 에러 메시지 처리를 위한 messageSource 빈 추가 (validator에서 참조하므로 필수입니다) -->
 	<beans:bean id="messageSource" class="org.springframework.context.support.ResourceBundleMessageSource">
 		<beans:property name="basename" value="messages" />
 		<beans:property name="defaultEncoding" value="UTF-8" />

--- a/src/main/webapp/WEB-INF/spring/root-context.xml
+++ b/src/main/webapp/WEB-INF/spring/root-context.xml
@@ -7,10 +7,13 @@
 	http://www.springframework.org/schema/context 
 	http://www.springframework.org/schema/context/spring-context.xsd">
 	
+	
 	<!-- DB 프로퍼티 파일을 Root에서 로드하여 프로젝트 전역에서 사용 가능하게 함 -->
-	<context:property-placeholder location="classpath:db.properties" />
-		
-	<!-- JavaMailSender 설정 -->
+	<context:property-placeholder location="classpath:config-${environment}.properties" />
+	
+	<context:component-scan base-package="com.fairplay.util" />
+	
+	<!-- JavaMailSender 설정 -->	
 	<bean id="mailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">
 	    <property name="host" value="smtp.mail.nate.com" />
 	    <property name="port" value="465" />


### PR DESCRIPTION
제목: [Feature] 운영 및 로컬 환경 분리 및 파일 업로드 경로 최적화

개요
현재 프로젝트가 로컬 개발 환경에 고정되어 있어, 향후 AWS/Docker 배포 시 소스 코드를 수정해야 하는 번거로움이 있었습니다. 이를 해결하기 위해 런타임 시점에 환경 설정을 주입받는 구조로 개선했습니다.

주요 변경 사항

환경별 프로퍼티 분리: config-local.properties, config-prod.properties 도입.

동적 설정 주입: JVM 옵션(-Denvironment)을 통해 실행 환경에 맞는 설정을 자동으로 로드하도록 root-context.xml 수정.

Context 계층 구조 대응: Root와 Servlet 컨텍스트 모두에서 프로퍼티를 정상적으로 참조할 수 있도록 설정 보완.

FileUploadUtil 개선:

하드코딩된 경로를 제거하고 ${upload.path} 프로퍼티를 참조하도록 변경.

File 클래스를 활용하여 윈도우/리눅스 간 경로 호환성 확보.

테스트 결과 

[x] 로컬 환경에서 -Denvironment=local 옵션으로 DB 접속 확인.

[x] C:\upload\profile 경로에 실제 파일 저장 및 404 없이 이미지 출력 확인.

[x] 설정되지 않은 변수 사용 시 예외 처리 확인.