### PR TITLE
[FIX] 히스토리 수정 페이지 이미지 미리보기 및 파일 교체 로직 개선

### DIFF
--- a/src/main/java/com/fairplay/controller/HistoryController.java
+++ b/src/main/java/com/fairplay/controller/HistoryController.java
@@ -322,62 +322,72 @@ public class HistoryController {
 	    return "historyUpdateForm";
 	}
     
-  // 5. 수정 처리
+	//5. 수정 처리
 	@PostMapping("/update")
 	public String updateHistory(
-	        HttpServletRequest request,
-	        @RequestParam("id") int id,
-	        @RequestParam("todo_id") int todoId,
-	        @RequestParam("member_id") int memberId,
-	        @RequestParam("score") int score,
-	        @RequestParam("memo") String memo,
-	        @RequestParam("completed_at") 
-	        @DateTimeFormat(pattern = "yyyy-MM-dd") Date completedAt,
-	        @RequestParam(value = "photo", required = false) MultipartFile photo,
-	        HttpSession session
+	   HttpServletRequest request,
+	   @RequestParam("id") int id,
+	   @RequestParam("todo_id") int todoId,
+	   @RequestParam("member_id") int memberId,
+	   @RequestParam("score") int score,
+	   @RequestParam("memo") String memo,
+	   @RequestParam("completed_at") 
+	   @DateTimeFormat(pattern = "yyyy-MM-dd") Date completedAt,
+	   @RequestParam(value = "photo", required = false) MultipartFile photo,
+	   HttpSession session
 	) {
-
-	    Member loginMember = (Member) session.getAttribute("loginMember");
-	    if (loginMember == null) {
-	        return "redirect:/";
-	    }
-
-	    Todo todo = todoService.findById(todoId);
-	    Long groupId = Long.valueOf(todo.getGroup_id());
-	    Long loginUserId = Long.valueOf(loginMember.getId());
-
-	    if (!groupMemberService.isGroupMember(groupId, loginUserId)) {
-	        return "redirect:/";
-	    }
-	    
-	    // 기존 히스토리 불러오기
-	    History oldHistory = historyService.getHistoryByIdWithDetails(id);
-
-	    History history = new History();
-	    history.setId(id);
-	    history.setTodo_id(todoId);
-	    history.setMember_id(memberId);
-	    history.setCompleted_at(completedAt);	// 사용자가 선택한 날짜 그대로 저장
-	    history.setScore(score);
-	    history.setMemo(memo);
-
-	    if (photo != null && !photo.isEmpty()) {
-	        try {
-	            String fileName = photo.getOriginalFilename();
-	            // 하드코딩된 경로 대신 주입받은 uploadPath 사용
-	            File savedFile = new File(uploadPath, fileName);
-	            photo.transferTo(savedFile);
-	            history.setPhoto(fileName);
-	        } catch (Exception e) {
-	            e.printStackTrace();
-	        }
-	    } else {
-        // 새 파일 없으면 기존 사진 유지
-        history.setPhoto(oldHistory.getPhoto());
-	    }
-
-	    historyService.updateHistory(history);
-	    return "redirect:/history/all";
+	
+	 Member loginMember = (Member) session.getAttribute("loginMember");
+	 if (loginMember == null) {
+	   return "redirect:/";
+	 }
+	
+	 Todo todo = todoService.findById(todoId);
+	 Long groupId = Long.valueOf(todo.getGroup_id());
+	 Long loginUserId = Long.valueOf(loginMember.getId());
+	
+	 if (!groupMemberService.isGroupMember(groupId, loginUserId)) {
+	   return "redirect:/";
+	 }
+	 
+	 // 기존 히스토리 불러오기 (기존 사진 확인용)
+	 History oldHistory = historyService.getHistoryByIdWithDetails(id);
+	
+	 History history = new History();
+	 history.setId(id);
+	 history.setTodo_id(todoId);
+	 history.setMember_id(memberId);
+	 history.setCompleted_at(completedAt);
+	 history.setScore(score);
+	 history.setMemo(memo);
+	
+	 // 새 사진이 업로드되었을 때만 실행
+	 if (photo != null && !photo.isEmpty()) {
+	   try {
+	     // 1. 기존 파일이 있다면 삭제
+	     if (oldHistory.getPhoto() != null) {
+	       File oldFile = new File(uploadPath, oldHistory.getPhoto());
+	       if (oldFile.exists()) {
+	         oldFile.delete(); // 서버에서 물리적으로 파일 삭제!
+	       }
+	     }
+	
+	     // 2. 새 파일 저장 (파일명 중복 방지를 위해 타임스탬프 추가)
+	     String fileName = System.currentTimeMillis() + "_" + photo.getOriginalFilename();
+	     File savedFile = new File(uploadPath, fileName);
+	     photo.transferTo(savedFile);
+	     
+	     history.setPhoto(fileName); // DB에 새 파일명 저장
+	   } catch (Exception e) {
+	     e.printStackTrace();
+	   }
+	 } else {
+	   // 새 파일 없으면 기존 사진 유지
+	   history.setPhoto(oldHistory.getPhoto());
+	 }
+	
+	 historyService.updateHistory(history);
+	 return "redirect:/history/all";
 	}
 
 

--- a/src/main/webapp/WEB-INF/views/historyUpdateForm.jsp
+++ b/src/main/webapp/WEB-INF/views/historyUpdateForm.jsp
@@ -58,14 +58,23 @@
         <textarea name="memo" rows="4">${history.memo}</textarea>
       </div>
 
-      <div class="form-group">
-        <label>인증샷 업로드</label>
-        <c:if test="${not empty history.photo}">
-        	<img src="${pageContext.request.contextPath}/upload/${history.photo}" 
-             alt="기존 인증샷" style="max-width:100px; display:block; margin-bottom:10px;">
-    		</c:if>
-        <input type="file" name="photo" accept="image/*" />
-      </div>
+			<div class="form-group">
+			  <label>인증샷 업로드</label>
+			  
+			  <div class="image-preview-wrapper" style="margin-bottom:10px;">
+			    <c:choose>
+			      <c:when test="${not empty history.photo}">
+			        <img id="preview" src="${pageContext.request.contextPath}/upload/${history.photo}" 
+			             alt="인증샷" style="max-width:200px; display:block;">
+			      </c:when>
+			      <c:otherwise>
+			        <img id="preview" src="#" alt="미리보기" style="max-width:200px; display:none;">
+			      </c:otherwise>
+			    </c:choose>
+			  </div>
+			
+			  <input type="file" name="photo" id="photoInput" accept="image/*" onchange="previewImage(this)" />
+			</div>
 
       <div class="form-btns">
         <button type="submit" class="btn-submit">수정 완료</button>
@@ -73,6 +82,23 @@
       </div>
     </form>
   </div>
-
 </body>
+
+<script>
+  function previewImage(input) {
+    const preview = document.getElementById('preview');
+    
+    if (input.files && input.files[0]) {
+      const reader = new FileReader();
+      
+      reader.onload = function(e) {
+        preview.src = e.target.result;
+        preview.style.display = 'block';
+      };
+      
+      reader.readAsDataURL(input.files[0]);
+    }
+  }
+</script>
+
 </html>


### PR DESCRIPTION
## 작업 내용
히스토리 수정(Update) 시 발생하는 이미지 관련 버그를 수정하고 사용자 편의성을 개선했습니다.

**JSP & JavaScript**
-FileReader API를 이용하여 이미지 선택 시 화면에서 즉시 미리보기가 가능하도록 로직 추가
-기존 이미지가 없을 경우에도 새 이미지 선택 시 미리보기 영역이 활성화되도록 처리

**Controller**
-이미지 수정 시 서버 저장소 내의 기존 물리 파일 삭제 로직 추가 (서버 용량 관리 및 데이터 정합성 유지)
-System.currentTimeMillis()를 활용하여 업로드 파일명 중복 방지 및 브라우저 캐시 문제 해결